### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -1,5 +1,8 @@
 name: Branch Naming Convention
 
+permissions:
+  contents: read
+
 on:
   push:
     branches-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/0xf1f0/snakelle/security/code-scanning/1](https://github.com/0xf1f0/snakelle/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block that grants only the minimal required scopes for the `GITHUB_TOKEN`. Since this workflow only evaluates branch names and does not perform any API calls or repository modifications, it can safely run with read‑only access to repository contents (or even `permissions: {}` if you want to fully disable the token).

The single best fix without changing functionality is to define a workflow‑level `permissions` block with `contents: read`. This documents that the workflow only needs read access and ensures the token will not unexpectedly gain write access if repository defaults change or the workflow is copied elsewhere. Concretely, in `.github/workflows/branch-naming.yml`, add:

```yaml
permissions:
  contents: read
```

right after the `name:` declaration and before the `on:` block (lines 1–3). No additional imports or methods are needed because this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
